### PR TITLE
don't prepend outlet names with "sub"

### DIFF
--- a/app/src/components/data/DataSelectionTable.jsx
+++ b/app/src/components/data/DataSelectionTable.jsx
@@ -4,7 +4,7 @@ import { getAvailableOptions, downloadTimeseries } from "../../services/timeseri
 import "./DataSelection.css";
 
 const DataSelectionTable = ({ featureId, onClose }) => {
-  const outletId = `sub${featureId}`;
+  const outletId = `${featureId}`;
   const [options, setOptions] = useState({
     models: [],
     scenarios: [],

--- a/app/src/services/timeseriesApi.js
+++ b/app/src/services/timeseriesApi.js
@@ -1,5 +1,5 @@
 // TODO: Update this URL with the live api
-const BASE_URL = "https://beehive.pacificclimate.org/hydromosaic/api";
+const BASE_URL = "https://beehive.pacificclimate.org/hydromosaic";
 
 const formatUnit = (unit) => {
   return unit


### PR DESCRIPTION
* stops adding the string "sub" to outlet names, as it is not present in the newest batch of data
* sets the default development hydromosaic instance to [one in the same stack](https://github.com/pacificclimate/portainer-deployment/blob/837faa3bcd684a144f1cd4e806f2b1c564ce8bc7/apps/dev/bbox-server-demo/docker-compose.yaml#L134)

[Demo](https://beehive.pacificclimate.org/vec-hydro-portal)

Resolves #12 