### PR TITLE
fix url to use current host for timeseries api

### DIFF
--- a/app/src/services/timeseriesApi.js
+++ b/app/src/services/timeseriesApi.js
@@ -1,5 +1,5 @@
 // TODO: Update this URL with the live api
-const BASE_URL = "https://beehive.pacificclimate.org/hydromosaic";
+const BASE_URL = `${window.location.origin}/hydromosaic`;
 
 const formatUnit = (unit) => {
   return unit


### PR DESCRIPTION
resolves #15 