### PR TITLE
Add npm policy, node 24, pin CI

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:4.1.0": {
+      "version": "4.1.0",
+      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:7d979c4a36d595eb4ab79909caa3f396daf3b6152dcf38e8328ea4eff42206c7",
+      "integrity": "sha256:7d979c4a36d595eb4ab79909caa3f396daf3b6152dcf38e8328ea4eff42206c7"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,9 +3,9 @@
 {
 	"name": "Node.js & TypeScript",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/typescript-node:1-22-bookworm",
+	"image": "mcr.microsoft.com/devcontainers/typescript-node:24-bookworm",
 	"features": {
-		"ghcr.io/devcontainers/features/docker-in-docker:2": {
+		"ghcr.io/devcontainers/features/docker-in-docker:4.1.0": {
 			"moby": true,
 			"azureDnsAutoDetection": true,
 			"installDockerBuildx": true,
@@ -22,7 +22,7 @@
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "cd app && npm install",
+	"postCreateCommand": "cd app && sudo npm install --global npm@12 && echo \"Node: $(node --version)\" && echo \"npm:  $(npm --version)\" && test \"$(node --version | cut -d. -f1 | tr -d v)\" = \"24\" && test \"$(npm --version | cut -d. -f1)\" = \"12\" && npm ci",
 
 	// Configure tool-specific properties.
 	// "customizations": {},

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,17 +9,21 @@ on:
 jobs:
   publish-images:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ secrets.pcicdevops_at_dockerhub_username }}
           password: ${{ secrets.pcicdevops_at_dockerhub_password }}
 
       - name: Build and Publish App
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: docker/app/Dockerfile
@@ -29,7 +33,7 @@ jobs:
             ${{ github.ref_name == 'main' && 'pcic/chyp-app:latest' || '' }}
 
       - name: Build and Publish Data Import
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: docker/data-import/Dockerfile
@@ -39,7 +43,7 @@ jobs:
             ${{ github.ref_name == 'main' && 'pcic/chyp-data-import:latest' || '' }}
 
       - name: Build and Publish PostGIS
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: docker/PostGIS/Dockerfile
@@ -49,7 +53,7 @@ jobs:
             ${{ github.ref_name == 'main' && 'pcic/chyp-postgis:latest' || '' }}
 
       - name: Build and Publish BBOX server
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: docker/BBOX/Dockerfile
@@ -59,7 +63,7 @@ jobs:
             ${{ github.ref_name == 'main' && 'pcic/chyp-server:latest' || '' }}
 
       - name: Build and Publish Varnish
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: docker/varnish/Dockerfile

--- a/app/.npmrc
+++ b/app/.npmrc
@@ -1,0 +1,4 @@
+min-release-age=7
+strict-allow-scripts=true
+allow-git=root
+allow-remote=none

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "app",
-  "version": "0.0.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "app",
-      "version": "0.0.0",
+      "version": "2.2.0",
       "dependencies": {
         "leaflet": "^1.9.4",
         "leaflet.vectorgrid": "^1.3.0",
-        "pcic-react-leaflet-components": "github:pacificclimate/pcic-react-leaflet-components#3.2.0",
+        "pcic-react-leaflet-components": "github:pacificclimate/pcic-react-leaflet-components#3.3.0",
         "proj4": "^2.15.0",
         "proj4leaflet": "^1.0.2",
         "react": "^18.3.1",
@@ -29,6 +29,10 @@
         "eslint-plugin-react-refresh": "^0.4.16",
         "globals": "^15.14.0",
         "vite": "^6.0.5"
+      },
+      "engines": {
+        "node": "24.x",
+        "npm": "12.x"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -13502,8 +13506,8 @@
       }
     },
     "node_modules/pcic-react-leaflet-components": {
-      "version": "3.2.0",
-      "resolved": "git+ssh://git@github.com/pacificclimate/pcic-react-leaflet-components.git#d11604c6c3ff6ec0dbe96523d068639a8cf573e2",
+      "version": "3.3.0",
+      "resolved": "git+ssh://git@github.com/pacificclimate/pcic-react-leaflet-components.git#8d0eb69b7fab8e481f8858743d298bea4d01a942",
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.3.0",
@@ -13515,6 +13519,10 @@
         "react-scripts": "5.0.1",
         "svg-loaders-react": "^2.2.1",
         "web-vitals": "^2.1.4"
+      },
+      "engines": {
+        "node": "24.x",
+        "npm": "12.x"
       },
       "peerDependencies": {
         "@react-leaflet/core": "2.0.0",

--- a/app/package.json
+++ b/app/package.json
@@ -3,6 +3,16 @@
   "private": true,
   "version": "2.2.0",
   "type": "module",
+  "engines": {
+    "node": "24.x",
+    "npm": "12.x"
+  },
+  "allowScripts": {
+    "@swc/core@1.10.7": true,
+    "core-js@3.40.0": false,
+    "core-js-pure@3.40.0": false,
+    "esbuild@0.24.2": true
+  },
   "scripts": {
     "dev": "vite",
     "build": "vite build",
@@ -14,7 +24,7 @@
   "dependencies": {
     "leaflet": "^1.9.4",
     "leaflet.vectorgrid": "^1.3.0",
-    "pcic-react-leaflet-components": "github:pacificclimate/pcic-react-leaflet-components#3.2.0",
+    "pcic-react-leaflet-components": "github:pacificclimate/pcic-react-leaflet-components#3.3.0",
     "proj4": "^2.15.0",
     "proj4leaflet": "^1.0.2",
     "react": "^18.3.1",

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -1,16 +1,21 @@
 # Stage 1: Build the Vite app
-FROM node:22-alpine AS builder
+FROM node:24-alpine AS builder
 
 WORKDIR /app
 
-COPY ./app/package.json ./app/package-lock.json ./
-RUN npm install
+COPY ./app/package.json ./app/package-lock.json ./app/.npmrc ./
+RUN npm install --global npm@12 \
+    && echo "Node: $(node --version)" \
+    && echo "npm:  $(npm --version)" \
+    && test "$(node --version | cut -d. -f1 | tr -d v)" = "24" \
+    && test "$(npm --version | cut -d. -f1)" = "12" \
+    && npm ci
 
 COPY ./app /app
 RUN npm run build
 
 # Stage 2: Serve
-FROM node:22-alpine
+FROM node:24-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
- Require Node 24 and npm 12.
- Add an .npmrc security policy to reduce npm supply-chain risk
- Bump CI actions, pin commit SHAs